### PR TITLE
Ignore txes from p2p, include txes from kzcashd only

### DIFF
--- a/p2pool/data.py
+++ b/p2pool/data.py
@@ -145,8 +145,8 @@ class Share(object):
             else:
                 if known_txs is not None:
                     this_size = kzc_data.tx_type.packed_size(known_txs[tx_hash])
-                    if new_transaction_size + this_size > 50000: # only allow 50 kB of new txns/share
-                        break
+                    # if new_transaction_size + this_size > 50000: # only allow 50 kB of new txns/share
+                    #     break
                     new_transaction_size += this_size
                 new_transaction_hashes.append(tx_hash)
                 this = [0, len(new_transaction_hashes)-1]
@@ -379,9 +379,11 @@ class Share(object):
             if all_txs_size > 1000000:
                 return True, 'txs over block size limit'
             
+            '''
             new_txs_size = sum(kzc_data.tx_type.packed_size(known_txs[tx_hash]) for tx_hash in self.share_info['new_transaction_hashes'])
             if new_txs_size > 50000:
                 return True, 'new txs over limit'
+            '''
         
         return False, None
     

--- a/p2pool/kzc/p2p.py
+++ b/p2pool/kzc/p2p.py
@@ -72,10 +72,10 @@ class Protocol(p2protocol.Protocol):
     ])
     def handle_inv(self, invs):
         for inv in invs:
-            if inv['type'] == 'tx':
-                self.send_getdata(requests=[inv])
-            elif inv['type'] == 'block':
+            if inv['type'] == 'block':
                 self.factory.new_block.happened(inv['hash'])
+            elif inv['type'] == 'tx':
+                self.send_getdata(requests=[inv])
             else:
                 if p2pool.DEBUG:
                     print 'Unneeded inv type', inv

--- a/p2pool/node.py
+++ b/p2pool/node.py
@@ -270,6 +270,7 @@ class Node(object):
             print
             print 'GOT BLOCK FROM PEER! Passing to kzcd! %s kzc: %s%064x' % (p2pool_data.format_hash(share.hash), self.net.PARENT.BLOCK_EXPLORER_URL_PREFIX, share.header_hash)
             print
+            self.factory.new_block.happened(share.hash)
         
         def forget_old_txs():
             new_known_txs = {}

--- a/p2pool/p2p.py
+++ b/p2pool/p2p.py
@@ -332,7 +332,9 @@ class Protocol(p2protocol.Protocol):
             if share.VERSION >= 13:
                 # send full transaction for every new_transaction_hash that peer does not know
                 for tx_hash in share.share_info['new_transaction_hashes']:
-                    assert tx_hash in known_txs, 'tried to broadcast share without knowing all its new transactions'
+                    # assert tx_hash in known_txs, 'tried to broadcast share without knowing all its new transactions'
+                    if tx_hash not in known_txs:
+                        print "WARN: Tried to broadcast share without knowing transaction %064x" % (tx_hash)
                     if tx_hash not in self.remote_tx_hashes:
                         tx_hashes.add(tx_hash)
                 continue

--- a/p2pool/work.py
+++ b/p2pool/work.py
@@ -103,6 +103,8 @@ class WorkerBridge(worker_interface.WorkerBridge):
             if bb is not None and bb['previous_block'] == t['previous_block'] and self.node.net.PARENT.POW_FUNC(kzc_data.block_header_type.pack(bb)) <= t['bits'].target:
                 print 'Skipping from block %x to block %x! NewHeight=%s' % (bb['previous_block'],
                     self.node.net.PARENT.BLOCKHASH_FUNC(kzc_data.block_header_type.pack(bb)),t['height']+1,)
+                '''
+                # New block template from KZCash daemon only
                 t = dict(
                     version=bb['version'],
                     previous_block=self.node.net.PARENT.BLOCKHASH_FUNC(kzc_data.block_header_type.pack(bb)),
@@ -118,6 +120,7 @@ class WorkerBridge(worker_interface.WorkerBridge):
                     payment_amount=self.node.kzcd_work.value['payment_amount'],
                     packed_payments=self.node.kzcd_work.value['packed_payments'],
                 )
+                '''
 
             self.current_work.set(t)
         self.node.kzcd_work.changed.watch(lambda _: compute_work())
@@ -403,6 +406,8 @@ class WorkerBridge(worker_interface.WorkerBridge):
                         print
                         print 'GOT BLOCK FROM MINER! Passing to kzcd! %s%064x' % (self.node.net.PARENT.BLOCK_EXPLORER_URL_PREFIX, header_hash)
                         print
+                        # New block found
+                        self.node.factory.new_block.happened(header_hash)
             except:
                 log.err(None, 'Error while processing potential block:')
 


### PR DESCRIPTION
* Fix submit_block
* Ignore new txs from p2p, peers and always get block template from KZCash Core.
* No restriction for new txs size since we get new txs only from getblocktemplate's result
* Revert fix masternode
* known_txs should be updated but will not be used for generate works
* remove known txs checking in sendShares
* Add warning tried to send shares without know transaction.
* show tx_hash as %064x

Based on
dashpay/p2pool-dash@bce55f1c
dashpay/p2pool-dash@18dc987